### PR TITLE
High Resolution Maeda

### DIFF
--- a/vtcalcs/src/vtcalcs.h
+++ b/vtcalcs/src/vtcalcs.h
@@ -33,8 +33,8 @@
 	int	nfrms, nfrmmax = 8;	/* number of formant frequencies  */
 	float	frm[8], bw[8], amp[8];	/* formant freqs. and amplitude   */
 	int ntf;
-	float tfmag[1024];
-	float tffreq[1024];
+	float tfmag[8192];
+	float tffreq[8192];
 
 	vp_lo_frame vp1 = { 1, 0.5, 5.0, 49., 25. }; 	/* area_function  */
 	vp_lo_frame vp2 = { 2, 0.5, 32., 49., 37. };    /* VT transfer	  */

--- a/vtcalcs/src/vtf_lib.c
+++ b/vtcalcs/src/vtf_lib.c
@@ -827,7 +827,7 @@ void	calplot_tf_FBA (
 	float *tffreq, /* transfer function freq */
 	int *ncount)	/* no of points */
 {
-	float	df, dfmin = .5f, dfmax = 40.f;			/* in Hz */
+	float	df, dfmin = .5f, dfmax = 1.f;			/* in Hz */
 	float	freq, freq2, mag, mag1, mag2, mag3;
 	float	fmin = 0.f, ftic = 0.2f, fmax = 5.f;		/* in kHz */
 	int	i, j,count = 0;
@@ -900,17 +900,17 @@ void	calplot_tf_FBA (
 				frm[j]   = freq2;		/* Fn in Hz    */
 				amp[j++] = mag2;		/* An in dB    */
 			}
-			/* adapt frequency step size */	     
-			if ( fabs(mag3 - mag2) > 1.f )
-			{
-				df = df - 8;
-				if( df <= dfmin ) df = dfmin;
-			}
-			else
-			{ 
-				df = df + 8;
-				if( df >= dfmax ) df = dfmax;
-			}
+			///* adapt frequency step size */	     
+			//if ( fabs(mag3 - mag2) > 1.f )
+			//{
+			//	df = df - 8;
+			//	if( df <= dfmin ) df = dfmin;
+			//}
+			//else
+			//{ 
+			//	df = df + 8;
+			//	if( df >= dfmax ) df = dfmax;
+			//}
 			mag1 = mag2;
 			mag2 = mag3;
 			freq2 = freq;

--- a/vtcalcs/src/vtsimul.h
+++ b/vtcalcs/src/vtsimul.h
@@ -62,8 +62,8 @@ void	calplot_tf_FA
 	   (char *title, int frmmax, float *frm, float *amp,
 	    int *nfrms, vp_lo_frame vp);
 void	calplot_tf_FBA
-	   (char *title, int frmmax, float *frm, float *bw, float *amp,
-	    int *nfrms, vp_lo_frame vp );
+	   (int frmmax, float *frm, float *bw, float *amp,int *nfrms,float *tf,int *ncount);
+
 void	calmultiplot_tf_FA
 	   (int entry, char *title, char *vowel_code,
 	    int frmmax, float *frm, float *amp, int *nfrms, vp_lo_frame vp);

--- a/vtcalcs/src/vtsimul.h
+++ b/vtcalcs/src/vtsimul.h
@@ -62,7 +62,8 @@ void	calplot_tf_FA
 	   (char *title, int frmmax, float *frm, float *amp,
 	    int *nfrms, vp_lo_frame vp);
 void	calplot_tf_FBA
-	   (int frmmax, float *frm, float *bw, float *amp,int *nfrms,float *tf,int *ncount);
+	   (int nfrmmax, float *frm, float *bw, float *amp,int *nfrms,float *tfmag,float *tffreq,int *ncount);
+
 
 void	calmultiplot_tf_FA
 	   (int entry, char *title, char *vowel_code,
@@ -72,7 +73,7 @@ void	calmultiplot_tf_FA
 void	calplot_tf_FA
 	   (int frmmax, float *frm, float *amp,int *nfrms,float *tf,int *ncount);
 void	calplot_tf_FBA
-	   (int frmmax, float *frm, float *bw, float *amp,int *nfrms,float *tf,int *ncount);
+	   (int nfrmmax, float *frm, float *bw, float *amp,int *nfrms,float *tfmag,float *tffreq,int *ncount);
 
 void	calmultiplot_tf_FA
 	   (int entry, char *title, char *vowel_code,


### PR DESCRIPTION
In the original version that was developed many years ago, a formant peak searching algorithm that changes frequency step size was implemented, presumably to reduce computational costs. Such algorithm sometimes would have large frequency step sizes such as 40 Hz. This new version has the adaptive search algorithm removed and always searches formant peaks with a small frequency step (i.e., 1 Hz) instead. It does increase computational costs, but such increases can be considered somewhat minimal thanks to today’s computing power. See Kim et al., (2023) for more details.